### PR TITLE
[feat] 게시글 상세 조회 API

### DIFF
--- a/src/main/java/com/planit/domain/post/controller/PostController.java
+++ b/src/main/java/com/planit/domain/post/controller/PostController.java
@@ -1,36 +1,37 @@
-package com.planit.domain.post.controller;
+package com.planit.domain.post.controller; // 게시글 관련 컨트롤러 패키지
 
-import com.planit.domain.post.dto.PostListResponse;
-import com.planit.domain.post.entity.BoardType;
-import com.planit.domain.post.service.PostService;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
-import java.util.Collections;
-import java.util.Locale;
-import org.springframework.http.HttpStatus;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.server.ResponseStatusException;
+import com.planit.domain.post.dto.PostDetailResponse; // 상세 DTO
+import com.planit.domain.post.dto.PostListResponse; // 목록 DTO
+import com.planit.domain.post.entity.BoardType; // 게시판 타입 enum
+import com.planit.domain.post.service.PostService; // 게시판 서비스
+import jakarta.validation.constraints.Pattern; // 정규 표현식 검증
+import jakarta.validation.constraints.Size; // 길이 제한
+import java.util.Locale; // 로케일 기반 대소문자 처리
+import org.springframework.http.HttpStatus; // HTTP 상태
+import org.springframework.security.core.annotation.AuthenticationPrincipal; // 현재 인증자
+import org.springframework.security.core.userdetails.UserDetails; // UserDetails 인터페이스
+import org.springframework.validation.annotation.Validated; // 검증 활성화
+import org.springframework.web.bind.annotation.GetMapping; // GET 매핑
+import org.springframework.web.bind.annotation.PathVariable; // 경로 변수
+import org.springframework.web.bind.annotation.RequestMapping; // 클래스 단위 경로
+import org.springframework.web.bind.annotation.RequestParam; // 쿼리 파라미터
+import org.springframework.web.bind.annotation.RestController; // REST 컨트롤러
+import org.springframework.web.server.ResponseStatusException; // 예외 처리
 
-@RestController
-@RequestMapping("/posts")
-@Validated
+@RestController // REST API를 반환하는 컨트롤러
+@RequestMapping("/posts") // /api/posts 컨텍스트에 매핑
+@Validated // 매개변수 검증 활성화
 public class PostController {
 
-    private final PostService postService;
+    private final PostService postService; // 게시글 서비스 주입
 
     public PostController(PostService postService) {
         this.postService = postService;
     }
 
     /**
-     * 자유 게시판을 전제로 게시글 제목/내용 OR 검색(최소 2자 최대 24자, 특수문자/초성 불가),
-     * 정렬(dropdown: 최신, 댓글 순, 좋아요 순), 무한 스크롤 페이징을 조합하여 목록을 제공합니다.
-     * 매 요청은 posts/users/comments/likes/posted_images/post_ranking_snapshots 테이블을 조합한 결과이며,
-     * boardType이 FREE가 아닌 경우 v1 미구현 메시지를 반환합니다.
+     * 자유게시판 목록.
+     * 검색/정렬/페이징(mutable, posts/users/posted_images/comments/likes/post_ranking_snapshots 조합) 처리
      */
     @GetMapping
     public PostListResponse listPosts(
@@ -41,10 +42,9 @@ public class PostController {
         @RequestParam(defaultValue = "20") int size
     ) {
         if (!"FREE".equalsIgnoreCase(boardType)) {
-            // v1에서는 자유 게시판 외 탭 클릭 시 toplevel 뷰에 'v1 미구현 기능' 토스트를 띄우고 새로고침을 유도
             throw new ResponseStatusException(HttpStatus.NOT_IMPLEMENTED, "v1 미구현 기능");
         }
-        validateSearch(search);
+        validateSearch(search); // helper text 기준으로 검색어 검증
         PostService.SortOption sortOption;
         try {
             sortOption = PostService.SortOption.valueOf(sort.toUpperCase());
@@ -55,23 +55,31 @@ public class PostController {
         return postService.listPosts(resolvedBoardType, normalizeSearch(search), sortOption, page, size);
     }
 
+    /**
+     * 게시글 상세: 작성자 정보, 최대 5장 이미지, 좋아요·댓글 상태/카운트, 댓글 리스트/삭제 권한 제공
+     */
+    @GetMapping("/{postId}")
+    public PostDetailResponse getPostDetail(
+        @PathVariable Long postId,
+        @AuthenticationPrincipal UserDetails principal
+    ) {
+        String loginId = principal == null ? null : principal.getUsername();
+        return postService.getPostDetail(postId, loginId);
+    }
+
     private void validateSearch(String search) {
         if (search == null || search.isBlank()) {
             return;
         }
-        // 검색어 최소 옵션
         if (search.length() < 2) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "*최소 2글자 부터 검색 가능합니다.");
         }
-        // 최대 글자 제한
         if (search.length() > 24) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "*최대 24자까지 검색 가능합니다.");
         }
-        // 한국어 초성 입력 방지
         if (search.matches(".*[ㄱ-ㅎㅏ-ㅣ]+.*")) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "*올바른 검색어를 입력해주세요");
         }
-        // 한글/영어/숫자/공백 외 특수문자 금지
         if (!search.matches("^[가-힣a-zA-Z0-9\\s]+$")) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "*특수문자는 입력 불가합니다");
         }

--- a/src/main/java/com/planit/domain/post/dto/PostDetailResponse.java
+++ b/src/main/java/com/planit/domain/post/dto/PostDetailResponse.java
@@ -1,0 +1,100 @@
+package com.planit.domain.post.dto; // 게시글 상세 응답 DTO 패키지
+
+import java.time.LocalDateTime; // 생성/작성 시간 표현
+import java.util.Collections; // null 보호용 빈 리스트 반환
+import java.util.List; // 이미지/댓글 컬렉션
+import lombok.Getter; // Lombok getter 자동 생성
+
+@Getter
+public class PostDetailResponse {
+    private final Long postId; // 게시글 PK
+    private final String boardName; // 게시판 이름(예: 자유게시판)
+    private final String boardDescription; // 게시판 설명
+    private final String title; // 게시글 제목
+    private final String content; // 게시글 본문 (최대 1,000자)
+    private final LocalDateTime createdAt; // 작성 시각
+    private final AuthorInfo author; // 작성자 정보
+    private final List<PostImage> images; // 최대 5장 사진
+    private final Integer likeCount; // 총 좋아요 수
+    private final Integer commentCount; // 총 댓글 수
+    private final Boolean likedByRequester; // 현재 요청자가 좋아요 눌렀는지
+    private final List<CommentInfo> comments; // 댓글 목록 (20개)
+    private final Boolean editable; // 현재 요청자가 작성자인지 (수정/삭제 버튼 노출 판단)
+
+    public PostDetailResponse(Long postId,
+                              String boardName,
+                              String boardDescription,
+                              String title,
+                              String content,
+                              LocalDateTime createdAt,
+                              AuthorInfo author,
+                              List<PostImage> images,
+                              Integer likeCount,
+                              Integer commentCount,
+                              Boolean likedByRequester,
+                              List<CommentInfo> comments,
+                              Boolean editable) {
+        this.postId = postId;
+        this.boardName = boardName;
+        this.boardDescription = boardDescription;
+        this.title = title;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.author = author;
+        this.images = images == null ? Collections.emptyList() : images;
+        this.likeCount = likeCount;
+        this.commentCount = commentCount;
+        this.likedByRequester = likedByRequester;
+        this.comments = comments == null ? Collections.emptyList() : comments;
+        this.editable = editable;
+    }
+
+    @Getter
+    public static class AuthorInfo {
+        private final Long authorId; // 작성자 PK
+        private final String nickname; // 작성자 닉네임
+        private final Long profileImageId; // 프로필 이미지 (nullable)
+
+        public AuthorInfo(Long authorId, String nickname, Long profileImageId) {
+            this.authorId = authorId;
+            this.nickname = nickname;
+            this.profileImageId = profileImageId;
+        }
+    }
+
+    @Getter
+    public static class PostImage {
+        private final Long imageId; // 게시글 이미지 ID
+
+        public PostImage(Long imageId) {
+            this.imageId = imageId;
+        }
+    }
+
+    @Getter
+    public static class CommentInfo {
+        private final Long commentId; // 댓글 PK
+        private final Long authorId; // 댓글 작성자 PK
+        private final String authorNickname; // 댓글 작성자 닉네임
+        private final Long authorProfileImageId; // 댓글 작성자 프로필 이미지
+        private final String content; // 댓글 본문 (max 500자)
+        private final LocalDateTime createdAt; // 댓글 작성 시간
+        private final Boolean deletable; // 현재 요청자가 댓글 작성자인지 (삭제 버튼)
+
+        public CommentInfo(Long commentId,
+                           Long authorId,
+                           String authorNickname,
+                           Long authorProfileImageId,
+                           String content,
+                           LocalDateTime createdAt,
+                           Boolean deletable) {
+            this.commentId = commentId;
+            this.authorId = authorId;
+            this.authorNickname = authorNickname;
+            this.authorProfileImageId = authorProfileImageId;
+            this.content = content;
+            this.createdAt = createdAt;
+            this.deletable = deletable;
+        }
+    }
+}

--- a/src/main/java/com/planit/domain/post/dto/PostListResponse.java
+++ b/src/main/java/com/planit/domain/post/dto/PostListResponse.java
@@ -5,8 +5,8 @@ import lombok.Getter;
 
 @Getter
 public class PostListResponse {
-    private final List<PostSummaryResponse> posts; // 실제 카드 표현을 위한 게시글 모음
-    private final boolean hasMore; // 무한 스크롤 여부 (다음 페이지 존재 여부)
+    private final List<PostSummaryResponse> posts; // 게시글 카드로 사용할 리스트 (여러 테이블 조합 결과)
+    private final boolean hasMore; // 무한 스크롤을 위한 flag, 다음 페이지 데이터 존재 여부
 
     public PostListResponse(List<PostSummaryResponse> posts, boolean hasMore) {
         this.posts = posts;

--- a/src/main/java/com/planit/domain/post/entity/BoardType.java
+++ b/src/main/java/com/planit/domain/post/entity/BoardType.java
@@ -1,10 +1,10 @@
 package com.planit.domain.post.entity;
 
 /**
- * 게시판 유형을 enum으로 표현하여 DB와 Java 사이의 매핑을 명확히 합니다.
+ * 게시판 구분을 enum으로 관리함으로써 DB의 문자열 board_type과 안전하게 매핑합니다.
  */
 public enum BoardType {
-    FREE,
-    PLAN_SHARE,
-    PLACE_RECOMMEND
+    FREE, // 자유게시판
+    PLAN_SHARE, // 여행 일정 공유 게시판
+    PLACE_RECOMMEND // 장소 추천 게시판
 }

--- a/src/main/java/com/planit/domain/post/entity/Post.java
+++ b/src/main/java/com/planit/domain/post/entity/Post.java
@@ -11,28 +11,28 @@ import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.Getter;
 
-@Entity
-@Table(name = "posts")
+@Entity // posts 테이블과 매핑되는 JPA 엔티티
+@Table(name = "posts") // DB 테이블 지정
 @Getter
 public class Post {
-    @Id
+    @Id // PK
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "post_id")
-    private Long id;
+    private Long id; // 게시글 식별자
 
     @Column(name = "user_id", nullable = false)
-    private Long userId;
+    private Long userId; // 작성자 FK
 
     @Column(name = "title", nullable = false, length = 100)
-    private String title;
+    private String title; // 게시글 제목
 
     @Column(name = "content", columnDefinition = "TEXT")
-    private String content;
+    private String content; // 본문 (줄바꿈/공백 유지)
 
     @Enumerated(EnumType.STRING)
     @Column(name = "board_type", nullable = false)
-    private BoardType boardType;
+    private BoardType boardType; // 게시판 구분 (enum으로 관리)
 
     @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
+    private LocalDateTime createdAt; // 등록 시점
 }

--- a/src/main/java/com/planit/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/planit/domain/post/repository/PostRepository.java
@@ -1,28 +1,28 @@
-package com.planit.domain.post.repository;
+package com.planit.domain.post.repository; // 게시글 도메인 저장소 패키지
 
-import java.util.Optional;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
+import java.util.Optional; // PostDetail 커스텀 조회용 Optional 타입
+import org.springframework.data.domain.Page; // 페이징 결과 타입
+import org.springframework.data.domain.Pageable; // Pageable 파라미터
+import org.springframework.data.jpa.repository.JpaRepository; // 기본 JPA 저장소
+import org.springframework.data.jpa.repository.Query; // Native Query 정의
+import org.springframework.data.repository.query.Param; // 쿼리 파라미터 바인딩
 
-public interface PostRepository extends JpaRepository<com.planit.domain.post.entity.Post, Long> {
+public interface PostRepository extends JpaRepository<com.planit.domain.post.entity.Post, Long>, PostRepositoryCustom {
 
     interface PostSummary {
-        Long getPostId();
-        String getTitle();
-        Long getAuthorId();
-        String getAuthorNickname();
-        Long getAuthorProfileImageId();
-        java.time.LocalDateTime getCreatedAt();
-        Long getLikeCount();
-        Long getCommentCount();
-        Long getRepresentativeImageId();
-        Double getRankingScore();
+        Long getPostId(); // 게시글 PK
+        String getTitle(); // 제목
+        Long getAuthorId(); // 작성자 PK
+        String getAuthorNickname(); // 작성자 닉네임
+        Long getAuthorProfileImageId(); // 프로필 이미지 ID
+        java.time.LocalDateTime getCreatedAt(); // 작성 시간
+        Long getLikeCount(); // 최근 1년 좋아요
+        Long getCommentCount(); // 최근 1년 댓글
+        Long getRepresentativeImageId(); // 대표 이미지 ID (null)
+        Double getRankingScore(); // ranking snapshot 값
     }
 
-    // posts, users, comments, likes, posted_images, post_ranking_snapshots를 조합한 요약 조회
+    // 자유게시판 목록용 네이티브 쿼리: posts + users + user_image + likes/comments + ranking 스냅샷 결합
     @Query(
         value =
             "select "

--- a/src/main/java/com/planit/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/planit/domain/post/repository/PostRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.planit.domain.post.repository; // 커스텀 리포지토리 패키지
+
+import com.planit.domain.post.dto.PostDetailResponse; // 상세 DTO
+import java.util.Optional; // 결과 Optional로 반환
+
+public interface PostRepositoryCustom {
+    /**
+     * 게시글 상세 조회: 요청자 ID까지 함께 전달해 좋아요/댓글/삭제 권한 판별
+     */
+    Optional<PostDetailResponse> findDetailById(Long postId, Long requesterId);
+}

--- a/src/main/java/com/planit/domain/post/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/com/planit/domain/post/repository/PostRepositoryCustomImpl.java
@@ -1,0 +1,175 @@
+package com.planit.domain.post.repository; // 커스텀 리포지토리 구현 패키지
+
+import com.planit.domain.post.dto.PostDetailResponse; // DTO
+import com.planit.domain.post.dto.PostDetailResponse.CommentInfo;
+import com.planit.domain.post.dto.PostDetailResponse.PostImage;
+import com.planit.domain.post.entity.BoardType;
+import java.math.BigInteger;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository // 커스텀 리포지토리 구현체
+public class PostRepositoryCustomImpl implements PostRepositoryCustom {
+
+    private static final int MAX_COMMENT_PAGE_SIZE = 20; // 20개 댓글씩 조회
+    private static final Map<BoardType, String> BOARD_NAMES = Map.of(
+        BoardType.FREE, "자유게시판",
+        BoardType.PLAN_SHARE, "일정 공유",
+        BoardType.PLACE_RECOMMEND, "장소 추천"
+    ); // 게시판 이름 매핑
+    private static final Map<BoardType, String> BOARD_DESCRIPTIONS = Map.of(
+        BoardType.FREE, "자유롭게 이야기하는 공간",
+        BoardType.PLAN_SHARE, "함께 일정 계획을 공유",
+        BoardType.PLACE_RECOMMEND, "좋은 장소 추천하기"
+    ); // 게시판 설명
+
+    @PersistenceContext
+    private EntityManager entityManager; // 직접 native query 실행
+
+    @Override
+    public Optional<PostDetailResponse> findDetailById(Long postId, Long requesterId) {
+        Query baseQuery = entityManager.createNativeQuery("""
+            select p.post_id,
+                   p.title,
+                   p.content,
+                   p.created_at,
+                   p.board_type,
+                   u.user_id,
+                   u.nickname,
+                   ui.image_id,
+                   (select count(1) from likes l where l.post_id = p.post_id) as like_count,
+                   (select count(1) from comments c where c.post_id = p.post_id) as comment_count,
+                   case
+                     when :requesterId < 0 then 0
+                     when exists(select 1 from likes l2 where l2.post_id = p.post_id and l2.user_id = :requesterId) then 1
+                     else 0
+                   end as liked
+            from posts p
+            join users u on u.user_id = p.user_id and u.is_deleted = 0
+            left join user_image ui on ui.user_id = u.user_id
+            where p.post_id = :postId
+            """); // posts+users+user_image 조합
+        baseQuery.setParameter("postId", postId);
+        baseQuery.setParameter("requesterId", requesterId == null ? -1L : requesterId);
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows = baseQuery.getResultList();
+        if (rows.isEmpty()) {
+            return Optional.empty();
+        }
+        Object[] row = rows.get(0);
+        Long authorId = ((Number) row[5]).longValue();
+        Long profileImageId = row[7] == null ? null : ((Number) row[7]).longValue();
+        String boardTypeValue = (String) row[4];
+        BoardType boardType = BoardType.FREE;
+        if (boardTypeValue != null) {
+            try {
+                boardType = BoardType.valueOf(boardTypeValue);
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
+        PostDetailResponse.AuthorInfo author = new PostDetailResponse.AuthorInfo(
+            authorId,
+            (String) row[6],
+            profileImageId
+        ); // 작성자 정보 구성
+        Long likeCount = row[8] == null ? 0L : ((Number) row[8]).longValue();
+        Long commentCount = row[9] == null ? 0L : ((Number) row[9]).longValue();
+        Boolean liked = Objects.equals(row[10], BigInteger.ONE);
+        List<PostImage> images = fetchImages(postId); // 최대 5개 이미지 조회
+        List<CommentInfo> comments = fetchComments(postId, requesterId); // 댓글 조회
+        boolean editable = requesterId != null && requesterId.equals(authorId); // 수정/삭제 버튼 판단
+        String boardName = BOARD_NAMES.getOrDefault(boardType, "자유게시판");
+        String boardDescription = BOARD_DESCRIPTIONS.getOrDefault(boardType, "자유롭게 이야기하는 공간");
+        Timestamp createdTimestamp = (Timestamp) row[3];
+        LocalDateTime createdAt = createdTimestamp == null ? null : createdTimestamp.toLocalDateTime();
+        PostDetailResponse detail = new PostDetailResponse(
+            ((Number) row[0]).longValue(),
+            boardName,
+            boardDescription,
+            (String) row[1],
+            (String) row[2],
+            createdAt,
+            author,
+            images,
+            likeCount.intValue(),
+            commentCount.intValue(),
+            liked,
+            comments,
+            editable
+        ); // DTO 구성하여 반환
+        return Optional.of(detail);
+    }
+
+    private List<PostImage> fetchImages(Long postId) {
+        Query imageQuery = entityManager.createNativeQuery("""
+            select pi.image_id
+            from posted_images pi
+            where pi.post_id = :postId
+            order by pi.id asc
+            limit 5
+            """); // posted_images에서 최대 5장 이미지 조회
+        imageQuery.setParameter("postId", postId);
+        @SuppressWarnings("unchecked")
+        List<BigInteger> results = imageQuery.getResultList();
+        if (results.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<PostImage> images = new ArrayList<>();
+        for (BigInteger value : results) {
+            images.add(new PostImage(value.longValue()));
+        }
+        return images;
+    }
+
+    private List<CommentInfo> fetchComments(Long postId, Long requesterId) {
+        Query commentQuery = entityManager.createNativeQuery("""
+            select c.comment_id,
+                   c.user_id,
+                   u.nickname,
+                   ui.image_id,
+                   c.content,
+                   c.created_at
+            from comments c
+            join users u on u.user_id = c.user_id and u.is_deleted = 0
+            left join user_image ui on ui.user_id = u.user_id
+            where c.post_id = :postId
+            order by c.created_at asc
+            limit :limit
+            """); // 댓글 20개 오래된 순
+        commentQuery.setParameter("postId", postId);
+        commentQuery.setParameter("limit", MAX_COMMENT_PAGE_SIZE);
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows = commentQuery.getResultList();
+        if (rows.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<CommentInfo> comments = new ArrayList<>();
+        for (Object[] row : rows) {
+            Long authorId = ((Number) row[1]).longValue();
+            Long profileImageId = row[3] == null ? null : ((Number) row[3]).longValue();
+            boolean deletable = requesterId != null && requesterId.equals(authorId);
+            Timestamp commentTimestamp = (Timestamp) row[5];
+            LocalDateTime commentCreatedAt = commentTimestamp == null ? null : commentTimestamp.toLocalDateTime();
+            comments.add(new CommentInfo(
+                ((Number) row[0]).longValue(),
+                authorId,
+                (String) row[2],
+                profileImageId,
+                (String) row[4],
+                commentCreatedAt,
+                deletable
+            ));
+        }
+        return comments;
+    }
+}

--- a/src/main/java/com/planit/domain/post/service/PostService.java
+++ b/src/main/java/com/planit/domain/post/service/PostService.java
@@ -1,11 +1,15 @@
 package com.planit.domain.post.service;
 
+import com.planit.domain.post.dto.PostDetailResponse;
 import com.planit.domain.post.dto.PostListResponse;
 import com.planit.domain.post.dto.PostSummaryResponse;
 import com.planit.domain.post.entity.BoardType;
 import com.planit.domain.post.repository.PostRepository;
+import com.planit.domain.user.repository.UserRepository;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -16,11 +20,11 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class PostService {
-    private final PostRepository postRepository;
+    private final PostRepository postRepository; // Repository/ 커스텀 and list
+    private final UserRepository userRepository; // 사용자 정보 조회
 
     /**
-     * 자유 게시판 기준으로 posts, users, comments, likes, posted_images, post_ranking_snapshots를 결합해
-     * 검색/정렬/페이징된 게시물 카드를 구성합니다.
+     * 자유 게시판 목록 조회: posts/users/posted_images/comments/likes/post_ranking_snapshots를 조합한 DTO를 반환
      */
     public PostListResponse listPosts(
         BoardType boardType,
@@ -29,7 +33,7 @@ public class PostService {
         int page,
         int size
     ) {
-        // 정렬 기준에 따라 Pageable 생성
+        // Pageable을 생성하여 정렬/페이징을 적용
         Pageable pageable = PageRequest.of(page, size, Sort.by(sortOption.getSortProperty()).descending());
         // 검색어를 like 패턴으로 변환
         String pattern = search == null || search.isBlank() ? "%" : "%" + search + "%";
@@ -54,8 +58,27 @@ public class PostService {
             ))
             // DTO 리스트로 수집
             .collect(Collectors.toList());
-        // 다음 페이지 존재 여부를 함께 반환
+        // 무한 스크롤을 위한 다음 페이지 존재 여부 전달
         return new PostListResponse(items, result.hasNext());
+    }
+
+    /**
+     * 상세 페이지: 게시판 이름/설명, 작성자/좋아요/이미지/댓글 상태까지 포함한 DTO 반환
+     */
+    public PostDetailResponse getPostDetail(Long postId, String loginId) {
+        Long requesterId = resolveRequesterId(loginId);
+        return postRepository.findDetailById(postId, requesterId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 게시글입니다."));
+    }
+
+    // 요청자 loginId로 실제 사용자 PK를 얻어 Authentication 기반 권한 판단에 사용
+    private Long resolveRequesterId(String loginId) {
+        if (loginId == null) {
+            return null;
+        }
+        return userRepository.findByLoginIdAndDeletedFalse(loginId)
+            .map(com.planit.domain.user.entity.User::getId)
+            .orElse(null);
     }
 
     public enum SortOption {


### PR DESCRIPTION
## 기능
- 게시글 상세 조회 API 구현

## API
- GET /api/posts/{postId}

## 조회 내용
- 게시글 기본 정보 (제목, 내용, 작성일)
- 작성자 정보 (닉네임, 프로필 이미지)
- 좋아요 수 / 댓글 수
- 대표 이미지

## 테스트
- 존재하는 게시글 ID로 정상 조회 확인
- 존재하지 않는 ID 요청 시 예외 응답 확인