### PR TITLE
[feat] 게시글 댓글 작성 API 구현

### DIFF
--- a/src/main/java/com/planit/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/planit/domain/comment/controller/CommentController.java
@@ -1,0 +1,43 @@
+package com.planit.domain.comment.controller;
+
+import com.planit.domain.comment.dto.CommentDetail;
+import com.planit.domain.comment.dto.CommentRequest;
+import com.planit.domain.comment.dto.CommentResponse;
+import com.planit.domain.comment.service.CommentService;
+import java.util.List;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/posts/{postId}/comments")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @GetMapping
+    public List<CommentDetail> listComments(@PathVariable Long postId) {
+        return commentService.listComments(postId);
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public CommentResponse createComment(
+        @PathVariable Long postId,
+        @AuthenticationPrincipal UserDetails principal,
+        @Valid @RequestBody CommentRequest request
+    ) {
+        String loginId = principal.getUsername();
+        return commentService.addComment(postId, loginId, request);
+    }
+}

--- a/src/main/java/com/planit/domain/comment/dto/CommentDetail.java
+++ b/src/main/java/com/planit/domain/comment/dto/CommentDetail.java
@@ -1,0 +1,31 @@
+package com.planit.domain.comment.dto;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 댓글 상세 정보를 담는 DTO
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class CommentDetail {
+    private Long commentId;
+    private String content;
+    private LocalDateTime createdAt;
+    private Long authorId;
+    private String authorNickname;
+    private Long authorProfileImageId;
+
+    public CommentDetail(Long commentId, String content, LocalDateTime createdAt, Long authorId,
+                         String authorNickname, Long authorProfileImageId) {
+        this.commentId = commentId;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.authorId = authorId;
+        this.authorNickname = authorNickname;
+        this.authorProfileImageId = authorProfileImageId;
+    }
+}

--- a/src/main/java/com/planit/domain/comment/dto/CommentRequest.java
+++ b/src/main/java/com/planit/domain/comment/dto/CommentRequest.java
@@ -1,0 +1,18 @@
+package com.planit.domain.comment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 게시글 상세 조회에서 새로운 댓글 등록 요청 DTO.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class CommentRequest {
+    @NotBlank(message = "*댓글을 입력해주세요.")
+    private String content;
+}
+

--- a/src/main/java/com/planit/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/planit/domain/comment/dto/CommentResponse.java
@@ -1,0 +1,19 @@
+package com.planit.domain.comment.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 댓글 응답 DTO
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class CommentResponse {
+    private Long commentId;
+    private String authorNickname;
+    private Long authorProfileImageId;
+    private String content;
+    private String createdAt; // hh:mm / yyyy-MM-dd 형식
+}

--- a/src/main/java/com/planit/domain/comment/entity/Comment.java
+++ b/src/main/java/com/planit/domain/comment/entity/Comment.java
@@ -1,0 +1,54 @@
+package com.planit.domain.comment.entity;
+
+import com.planit.domain.post.entity.Post;
+import com.planit.domain.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 자유게시판 댓글 엔티티.
+ */
+@Entity
+@Table(name = "comments")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "author_id", nullable = false)
+    private User author;
+
+    @Column(nullable = false, columnDefinition = "text")
+    private String content;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    public boolean isDeleted() {
+        return deletedAt != null;
+    }
+}

--- a/src/main/java/com/planit/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/planit/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,9 @@
+package com.planit.domain.comment.repository;
+
+import com.planit.domain.comment.entity.Comment;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findAllByPostIdAndDeletedAtIsNullOrderByCreatedAtAsc(Long postId);
+}


### PR DESCRIPTION
## 개요
게시글에 댓글을 작성할 수 있는 API를 구현했습니다.  
JWT 인증 기반으로 로그인한 사용자만 댓글 작성이 가능하도록 처리했습니다.

---

## 구현 내용
- 댓글 작성 API 구현 (`POST /posts/{postId}/comments`)
- 로그인 사용자만 댓글 작성 가능 (JWT 인증)
- 게시글 존재 여부 검증
- 댓글 내용 유효성 검증 (빈 값 방지)
- 댓글 생성 시 작성자, 게시글 연관 관계 설정
- 댓글 Soft Delete 구조(`deleted_at`) 기반 설계

---

## 사용 테이블
- `comments`
- `posts`
- `users`

---

## 인증/인가
- `Authorization: Bearer {JWT}` 헤더 필요
- 인증되지 않은 요청은 `401 Unauthorized` 반환

---

## 테스트
- Swagger UI를 통해 댓글 작성 정상 동작 확인
- JWT 미포함 시 401 응답 확인
- DB `comments` 테이블에 데이터 정상 저장 확인

---

## ⚠️참고 사항
- 댓글 ID는 DB `AUTO_INCREMENT` 기반 생성
- 댓글 조회/삭제 API는 후속 작업에서 구현 예정
