### PR TITLE
[feat] 댓글 삭제 API 구현

### DIFF
--- a/src/main/java/com/planit/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/planit/domain/comment/controller/CommentController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -39,5 +40,16 @@ public class CommentController {
     ) {
         String loginId = principal.getUsername();
         return commentService.addComment(postId, loginId, request);
+    }
+
+    @DeleteMapping("/{commentId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteComment(
+        @PathVariable Long postId,
+        @PathVariable Long commentId,
+        @AuthenticationPrincipal UserDetails principal
+    ) {
+        String loginId = principal.getUsername();
+        commentService.deleteComment(commentId, loginId);
     }
 }

--- a/src/main/java/com/planit/domain/comment/service/CommentService.java
+++ b/src/main/java/com/planit/domain/comment/service/CommentService.java
@@ -58,4 +58,13 @@ public class CommentService {
         response.setCreatedAt(saved.getCreatedAt().toString());
         return response;
     }
+
+    @Transactional
+    public void deleteComment(Long commentId, String loginId) {
+        Comment comment = commentRepository.findById(commentId).orElseThrow();
+        if (!comment.getAuthor().getLoginId().equals(loginId)) {
+            throw new IllegalStateException("작성자만 삭제할 수 있습니다.");
+        }
+        comment.setDeletedAt(LocalDateTime.now());
+    }
 }


### PR DESCRIPTION
## 개요
게시글에 작성된 댓글을 삭제할 수 있는 API를 구현했습니다.  
댓글은 실제 삭제가 아닌 Soft Delete 방식으로 처리됩니다.

---

## 구현 내용
- 댓글 삭제 API 구현 (`DELETE /comments/{commentId}`)
- JWT 인증 기반 접근 제어
- 댓글 작성자 본인만 삭제 가능
- Soft Delete 방식 적용 (`deleted_at` 업데이트)

---

## 처리 정책
- 존재하지 않는 댓글 → `404 Not Found`
- 이미 삭제된 댓글 → `404 Not Found`
- 댓글 작성자가 아닌 경우 → `403 Forbidden`
- 인증 정보 미포함 또는 만료 → `401 Unauthorized`
- 정상 삭제 시 → `204 No Content`

---

## 사용 테이블
- `comments`
- `users`
- `posts` (존재 여부 확인용)

---

## 인증 / 인가
- `Authorization: Bearer {JWT}` 헤더 필수
- JWT subject와 댓글 `author_id` 일치 여부 검증

---

## 테스트
- Swagger UI를 통한 삭제 성공 확인
- 타 사용자 댓글 삭제 시 403 반환 확인
- 삭제된 댓글 재요청 시 404 반환 확인
- JWT 미포함 요청 시 401 반환 확인

---

## 참고 사항
- 댓글 데이터는 실제 삭제되지 않으며 `deleted_at`으로 관리
- 댓글 조회 API에서는 `deleted_at IS NULL` 조건으로 필터링