### PR TITLE
[feat] 게시글 댓글 조회 API 구현

### DIFF
--- a/src/main/java/com/planit/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/planit/domain/comment/repository/CommentRepository.java
@@ -3,7 +3,39 @@ package com.planit.domain.comment.repository;
 import com.planit.domain.comment.entity.Comment;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    List<Comment> findAllByPostIdAndDeletedAtIsNullOrderByCreatedAtAsc(Long postId);
+
+    @Query("""
+        select c
+        from Comment c
+        join fetch c.author
+        where c.post.id = :postId
+          and c.deletedAt is null
+        order by c.createdAt asc
+    """)
+    List<Comment> findAllByPostIdAndDeletedAtIsNullOrderByCreatedAtAsc(
+        @Param("postId") Long postId
+    );
+
+    @Query("""
+        select new com.planit.domain.comment.dto.CommentDetail(
+            c.id,
+            c.content,
+            c.createdAt,
+            c.author.id,
+            c.author.nickname,
+            c.author.profileImageId
+        )
+        from Comment c
+        where c.post.id = :postId
+          and c.deletedAt is null
+        order by c.createdAt asc
+    """)
+    List<com.planit.domain.comment.dto.CommentDetail> findDetailsByPostId(
+        @Param("postId") Long postId
+    );
+
 }

--- a/src/main/java/com/planit/domain/comment/service/CommentService.java
+++ b/src/main/java/com/planit/domain/comment/service/CommentService.java
@@ -11,7 +11,6 @@ import com.planit.domain.user.entity.User;
 import com.planit.domain.user.repository.UserRepository;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,17 +26,9 @@ public class CommentService {
     private final PostRepository postRepository;
     private final UserRepository userRepository;
 
+    @Transactional(readOnly = true)
     public List<CommentDetail> listComments(Long postId) {
-        return commentRepository.findAllByPostIdAndDeletedAtIsNullOrderByCreatedAtAsc(postId)
-            .stream()
-            .map(c -> new CommentDetail(
-                c.getId(),
-                c.getContent(),
-                c.getCreatedAt(),
-                c.getAuthor().getId(),
-                c.getAuthor().getNickname(),
-                c.getAuthor().getProfileImageId()))
-            .collect(Collectors.toList());
+        return commentRepository.findDetailsByPostId(postId);
     }
 
     @Transactional


### PR DESCRIPTION
### 작업 내용

* 게시글에 달린 댓글 목록을 조회하는 API를 구현했습니다.
* 댓글은 **오래된 순(ASC)** 으로 정렬되어 반환됩니다.
* **Soft Delete(`deleted_at`) 처리된 댓글은 조회 대상에서 제외**됩니다.
* 로그인한 사용자만 접근 가능하도록 **JWT 인증**을 적용했습니다.

---

### API 명세

* **Method**: `GET`
* **URL**: `/api/posts/{postId}/comments`
* **Auth**: Bearer Token (JWT)

---

### 응답 예시

#### 댓글이 없는 경우

```json
[]
```

#### 댓글이 있는 경우

```json
[
  {
    "commentId": 1,
    "content": "댓글 내용",
    "createdAt": "2026-01-27T15:20:00",
    "authorId": 8,
    "authorNickname": "sumini",
    "authorProfileImageId": 3
  }
]
```

---

### 테스트 결과

* 인증되지 않은 요청 → **401 Unauthorized**
* 인증된 요청 → **200 OK**
* 댓글이 없는 게시글 조회 시 → **빈 배열(`[]`) 반환 확인**
* Soft Delete 된 댓글은 조회되지 않음 확인

---

### 관련 테이블

* `comments`
* `posts`
* `users`
* `user_profile_images`

---

### 참고 사항

* 연관 엔티티 접근 시 Lazy Loading 이슈를 방지하기 위해 조회 범위를 DTO 기준으로 제한했습니다.
* 댓글 조회 결과가 없는 경우도 정상 케이스로 처리합니다.