### PR TITLE
[feat] 게시글 좋아요 토글 API 구현

### DIFF
--- a/src/main/java/com/planit/domain/like/controller/PostLikeController.java
+++ b/src/main/java/com/planit/domain/like/controller/PostLikeController.java
@@ -1,0 +1,53 @@
+package com.planit.domain.like.controller;
+
+import com.planit.domain.like.dto.PostLikeResponse;
+import com.planit.domain.like.service.PostLikeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/posts/{postId}/likes")
+@RequiredArgsConstructor
+public class PostLikeController {
+
+    private final PostLikeService likeService;
+
+    @GetMapping
+    @Operation(
+        summary = "게시글 좋아요 정보 조회",
+        description = "현재 게시글의 좋아요 총 개수와 요청한 사용자가 좋아요를 눌렀는지를 함께 반환합니다."
+    )
+    public PostLikeResponse getLikeInfo(
+        @PathVariable Long postId,
+        @AuthenticationPrincipal UserDetails principal
+    ) {
+        String loginId = principal != null ? principal.getUsername() : null;
+        return likeService.getPostLikeInfo(postId, loginId);
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(
+        summary = "게시글 좋아요 토글",
+        description = "로그인한 사용자가 해당 게시글의 좋아요/좋아요 취소를 수행합니다.",
+        security = @SecurityRequirement(name = "bearerAuth")
+    )
+    public void toggleLike(
+        @PathVariable Long postId,
+        @AuthenticationPrincipal UserDetails principal
+    ) {
+        String loginId = principal.getUsername();
+        likeService.toggleLike(postId, loginId);
+    }
+}

--- a/src/main/java/com/planit/domain/like/dto/PostLikeResponse.java
+++ b/src/main/java/com/planit/domain/like/dto/PostLikeResponse.java
@@ -1,0 +1,20 @@
+package com.planit.domain.like.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class PostLikeResponse {
+
+    private final Long postId;
+    private final long likeCount;
+    private final boolean likedByMe;
+
+    public static PostLikeResponse of(Long postId, long likeCount, boolean likedByMe) {
+        return new PostLikeResponse(postId, likeCount, likedByMe);
+    }
+}

--- a/src/main/java/com/planit/domain/like/entity/Like.java
+++ b/src/main/java/com/planit/domain/like/entity/Like.java
@@ -1,0 +1,55 @@
+package com.planit.domain.like.entity;
+
+import com.planit.domain.post.entity.Post;
+import com.planit.domain.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(
+    name = "likes",
+    uniqueConstraints = @UniqueConstraint(
+        name = "uk_likes_post_author",
+        columnNames = {"post_id", "author_id"}
+    )
+)
+@Getter
+@Setter
+@NoArgsConstructor
+public class Like {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "like_id")
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "author_id", nullable = false)
+    private User author;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    public static Like of(Post post, User author) {
+        Like like = new Like();
+        like.setPost(post);
+        like.setAuthor(author);
+        like.setCreatedAt(LocalDateTime.now());
+        return like;
+    }
+}

--- a/src/main/java/com/planit/domain/like/repository/PostLikeRepository.java
+++ b/src/main/java/com/planit/domain/like/repository/PostLikeRepository.java
@@ -1,0 +1,14 @@
+package com.planit.domain.like.repository;
+
+import com.planit.domain.like.entity.Like;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostLikeRepository extends JpaRepository<Like, Long> {
+
+    boolean existsByPostIdAndAuthorId(Long postId, Long authorId);
+
+    Optional<Like> findByPostIdAndAuthorId(Long postId, Long authorId);
+
+    long countByPostId(Long postId);
+}

--- a/src/main/java/com/planit/domain/like/service/PostLikeService.java
+++ b/src/main/java/com/planit/domain/like/service/PostLikeService.java
@@ -1,0 +1,44 @@
+package com.planit.domain.like.service;
+
+import com.planit.domain.like.dto.PostLikeResponse;
+import com.planit.domain.like.entity.Like;
+import com.planit.domain.like.repository.PostLikeRepository;
+import com.planit.domain.post.entity.Post;
+import com.planit.domain.post.repository.PostRepository;
+import com.planit.domain.user.entity.User;
+import com.planit.domain.user.repository.UserRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PostLikeService {
+
+    private final PostLikeRepository postLikeRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+    public PostLikeResponse getPostLikeInfo(Long postId, String loginId) {
+        boolean likedByMe = false;
+        if (loginId != null) {
+            Optional<User> user = userRepository.findByLoginIdAndDeletedFalse(loginId);
+            likedByMe = user.isPresent() && postLikeRepository.existsByPostIdAndAuthorId(postId, user.get().getId());
+        }
+        long likeCount = postLikeRepository.countByPostId(postId);
+        return PostLikeResponse.of(postId, likeCount, likedByMe);
+    }
+
+    @Transactional
+    public void toggleLike(Long postId, String loginId) {
+        User user = userRepository.findByLoginIdAndDeletedFalse(loginId).orElseThrow();
+        Post post = postRepository.findById(postId).orElseThrow();
+        Optional<Like> existing = postLikeRepository.findByPostIdAndAuthorId(postId, user.getId());
+        if (existing.isPresent()) {
+            postLikeRepository.delete(existing.get());
+        } else {
+            postLikeRepository.save(Like.of(post, user));
+        }
+    }
+}


### PR DESCRIPTION
## ✨ 작업 내용

게시글 좋아요 기능을 **토글(toggle) 방식**으로 구현했습니다.  
로그인한 사용자가 동일한 API를 통해 좋아요 / 좋아요 취소를 수행할 수 있습니다.

- 게시글 좋아요 토글 API 구현
- 기존 좋아요 존재 여부에 따라 생성 / 삭제 분기 처리
- JWT 인증 기반으로 로그인 사용자 식별
- 중복 좋아요 방지 로직 적용

---

## API 명세

- **POST** `/api/posts/{postId}/likes`
- 로그인 사용자만 요청 가능
- 요청 본문 없음

### 동작 방식
- 좋아요가 없을 경우 → 좋아요 생성
- 이미 좋아요가 있을 경우 → 좋아요 취소

---

## DB 변경 사항

- `likes` 테이블 사용
  - `like_id` (PK, auto_increment)
  - `post_id`
  - `author_id`
  - `created_at`

---

## 테스트 결과

- [x] 로그인 사용자 좋아요 생성 정상 동작
- [x] 동일 사용자 재요청 시 좋아요 취소 정상 동작
- [x] 비로그인 사용자 요청 시 401 반환
- [x] 중복 좋아요 생성 방지 확인

---

## 설계 의도

좋아요 기능은 상태 전이(toggle) 성격이 강한 기능이므로  
클라이언트의 상태 관리 부담을 줄이기 위해 서버에서 토글 방식으로 처리했습니다.  
이를 통해 API 수를 줄이고, 프론트엔드 구현을 단순화했습니다.