### PR TITLE
[feat] 게시글 상세 조회 응답 확장

### DIFF
--- a/src/main/java/com/planit/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/planit/domain/user/repository/UserRepository.java
@@ -34,9 +34,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
             u.nickname as nickname,
             u.profile_image_id as profileImageId,
             (select count(1) from posts p where p.user_id = u.user_id and p.is_deleted = 0) as postCount,
-            (select count(1) from comments c where c.author_id = u.user_id and c.deleted = 0) as commentCount,
-            (select count(1) from likes l where l.user_id = u.user_id) as likeCount,
-            (select count(1) from notifications n where n.receiver_id = u.user_id) as notificationCount
+            (select count(1) from comments c where c.author_id = u.user_id and c.deleted_at is null) as commentCount,
+            (select count(1) from likes l where l.author_id = u.user_id) as likeCount,
+            (select count(1) from notifications n where n.user_id = u.user_id) as notificationCount
         from users u
         where u.user_id = :userId and u.is_deleted = 0
     """, nativeQuery = true)


### PR DESCRIPTION
### 작업 내용

게시글 상세 조회 API의 응답 정보를 확장하여,
프론트에서 추가 요청 없이 상세 화면을 구성할 수 있도록 개선했습니다.

### 주요 변경 사항

* 게시글 상세 조회 응답에 **집계 정보 추가**

  * 좋아요 수
  * 댓글 수
  * 조회수 *(해당 시)*
* 로그인 사용자 기준

  * 내가 좋아요를 눌렀는지 여부 반환
* 연관 테이블을 활용한 집계 쿼리 추가

### 변경된 API

* `GET /posts/{postId}`

  * 기존 게시글 정보 + 집계 데이터 포함 응답

### 사용 테이블

* `posts`
* `users`
* `comments`
* `likes`
* `post_views` *(있는 경우)*

### 테스트 방법

1. 로그인 후 access token 발급
2. `/posts/{postId}` 호출
3. 응답에 집계 필드가 정상적으로 포함되는지 확인

### 참고 사항

* 조회 성능을 고려하여 단건 조회 기준으로 서브쿼리 방식 사용
* 추후 목록 조회 확장 시 JOIN + GROUP BY 방식으로 개선 예정