### PR TITLE
[feat] 게시글 검색 기능 구현

### DIFF
--- a/src/main/java/com/planit/domain/post/dto/PostSummaryResponse.java
+++ b/src/main/java/com/planit/domain/post/dto/PostSummaryResponse.java
@@ -5,16 +5,18 @@ import lombok.Getter;
 
 @Getter
 public class PostSummaryResponse {
-    private final Long postId; // 게시글 PK
-    private final String title; // 게시글 제목
-    private final Long authorId; // 작성자 PK
-    private final String authorNickname; // 작성자 닉네임
-    private final Long authorProfileImageId; // 작성자 프로필 이미지 ID
-    private final LocalDateTime createdAt; // 작성 시점
-    private final Long likeCount; // 좋아요 집계
-    private final Long commentCount; // 댓글 집계
-    private final Long representativeImageId; // 대표 이미지 ID
-    private final Double rankingScore; // 랭킹 스냅샷 기반 순위 지표
+    private final Long postId;
+    private final String title;
+    private final Long authorId;
+    private final String authorNickname;
+    private final Long authorProfileImageId;
+    private final LocalDateTime createdAt;
+    private final Long likeCount;
+    private final Long commentCount;
+    private final Long representativeImageId;
+    private final Double rankingScore;
+    private final String placeName;
+    private final String tripTitle;
 
     public PostSummaryResponse(
         Long postId,
@@ -26,7 +28,9 @@ public class PostSummaryResponse {
         Long likeCount,
         Long commentCount,
         Long representativeImageId,
-        Double rankingScore
+        Double rankingScore,
+        String placeName,
+        String tripTitle
     ) {
         this.postId = postId;
         this.title = title;
@@ -38,5 +42,7 @@ public class PostSummaryResponse {
         this.commentCount = commentCount;
         this.representativeImageId = representativeImageId;
         this.rankingScore = rankingScore;
+        this.placeName = placeName;
+        this.tripTitle = tripTitle;
     }
 }

--- a/src/main/java/com/planit/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/planit/domain/post/repository/PostRepository.java
@@ -1,74 +1,102 @@
-package com.planit.domain.post.repository; // 게시글 도메인 저장소 패키지
+package com.planit.domain.post.repository;
 
+import com.planit.domain.post.entity.Post;
+import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface PostRepository extends JpaRepository<com.planit.domain.post.entity.Post, Long>, PostRepositoryCustom {
+public interface PostRepository
+        extends JpaRepository<Post, Long>, PostRepositoryCustom {
 
+    /**
+     * 게시글 목록 Projection
+     */
     interface PostSummary {
-        Long getPostId(); // 게시글 PK
-        String getTitle(); // 제목
-        Long getAuthorId(); // 작성자 PK
-        String getAuthorNickname(); // 작성자 닉네임
-        Long getAuthorProfileImageId(); // 프로필 이미지 ID
-        java.time.LocalDateTime getCreatedAt(); // 작성 시간
-        Long getLikeCount(); // 최근 1년 좋아요
-        Long getCommentCount(); // 최근 1년 댓글
-        Long getRepresentativeImageId(); // 대표 이미지 ID (null)
-        Double getRankingScore(); // ranking snapshot 값
+        Long getPostId();
+        String getTitle();
+        Long getAuthorId();
+        String getAuthorNickname();
+        Long getAuthorProfileImageId();
+        LocalDateTime getCreatedAt();
+        Long getLikeCount();
+        Long getCommentCount();
+        Long getRepresentativeImageId();
+        Double getRankingScore();
+        String getPlaceName();
+        String getTripTitle();
     }
 
-    // 자유게시판 목록용 네이티브 쿼리: posts + users + user_image + likes/comments + ranking 스냅샷 결합
+    /**
+     * 자유게시판 목록 조회
+     * - Soft Delete 제외
+     * - 제목/본문 검색
+     * - 장소/여행 대표 정보 포함
+     */
     @Query(
-        value =
-            "select "
-                + "p.post_id as postId, "
-                + "p.title as title, "
-                + "u.user_id as authorId, "
-                + "u.nickname as authorNickname, "
-                + "ui.image_id as authorProfileImageId, "
-                + "p.created_at as createdAt, "
-                + "(select count(1) from likes l "
-                + " where l.post_id = p.post_id "
-                + "   and l.created_at >= date_sub(current_date(), interval 1 year)) as likeCount, "
-                + "(select count(1) from comments c "
-                + " where c.post_id = p.post_id "
-                + "   and c.created_at >= date_sub(current_date(), interval 1 year)) as commentCount, "
-                + "null as representativeImageId, "
-                + "(select pr.score from post_ranking_snapshots pr "
-                + " where pr.post_id = p.post_id "
-                + " order by pr.snapshot_date desc limit 1) as rankingScore "
-                + "from posts p "
-                + "join users u on u.user_id = p.user_id and u.is_deleted = 0 "
-                + "left join user_image ui on ui.user_id = u.user_id "
-                + "where p.board_type = :boardType "
-                + "and (coalesce(:search,'') = '' "
-                + " or lower(p.title) like lower(:pattern) "
-                + " or lower(p.content) like lower(:pattern)) "
-                + "order by p.created_at desc ",
-        countQuery =
-            "select count(*) from posts p "
-                + "join users u on u.user_id = p.user_id and u.is_deleted = 0 "
-                + "where p.board_type = :boardType "
-                + "and (coalesce(:search,'') = '' "
-                + " or lower(p.title) like lower(:pattern) "
-                + " or lower(p.content) like lower(:pattern)) ",
-        nativeQuery = true
+            value =
+                    "select "
+                            + "p.post_id as postId, "
+                            + "p.title as title, "
+                            + "u.user_id as authorId, "
+                            + "u.nickname as authorNickname, "
+                            + "ui.image_id as authorProfileImageId, "
+                            + "p.created_at as createdAt, "
+                            + "(select count(1) from likes l "
+                            + " where l.post_id = p.post_id "
+                            + "   and l.created_at >= date_sub(current_date(), interval 1 year)) as likeCount, "
+                            + "(select count(1) from comments c "
+                            + " where c.post_id = p.post_id "
+                            + "   and c.created_at >= date_sub(current_date(), interval 1 year)) as commentCount, "
+                            + "null as representativeImageId, "
+                            + "(select pr.score from post_ranking_snapshots pr "
+                            + " where pr.post_id = p.post_id "
+                            + " order by pr.snapshot_date desc limit 1) as rankingScore, "
+                            + "(select pl.name from posted_places pp "
+                            + " join places pl on pl.place_id = pp.place_id "
+                            + " where pp.post_id = p.post_id "
+                            + " limit 1) as placeName, "
+                            + "(select tr.title from posted_plans pt "
+                            + " join trips tr on tr.id = pt.trip_id "
+                            + " where pt.post_id = p.post_id "
+                            + " limit 1) as tripTitle "
+                            + "from posts p "
+                            + "join users u on u.user_id = p.user_id "
+                            + " and u.is_deleted = 0 "
+                            + "left join user_image ui on ui.user_id = u.user_id "
+                            + "where p.board_type = :boardType "
+                            + "and p.is_deleted = 0 "
+                            + "and ( :pattern = '%' "
+                            + "   or lower(p.title) like lower(:pattern) "
+                            + "   or lower(p.content) like lower(:pattern) ) "
+                            + "order by p.created_at desc",
+            countQuery =
+                    "select count(*) "
+                            + "from posts p "
+                            + "join users u on u.user_id = p.user_id "
+                            + " and u.is_deleted = 0 "
+                            + "where p.board_type = :boardType "
+                            + "and p.is_deleted = 0 "
+                            + "and ( :pattern = '%' "
+                            + "   or lower(p.title) like lower(:pattern) "
+                            + "   or lower(p.content) like lower(:pattern) )",
+            nativeQuery = true
     )
     Page<PostSummary> searchByBoardType(
-        @Param("boardType") String boardType,
-        @Param("search") String search,
-        @Param("pattern") String pattern,
-        Pageable pageable
+            @Param("boardType") String boardType,
+            @Param("pattern") String pattern,
+            Pageable pageable
     );
 
-    List<com.planit.domain.post.entity.Post> findByAuthorIdAndDeletedFalseOrderByCreatedAtDesc(
-        Long authorId,
-        Pageable pageable
+    /**
+     * 내 게시글 조회
+     */
+    List<Post> findByAuthorIdAndDeletedFalseOrderByCreatedAtDesc(
+            Long authorId,
+            Pageable pageable
     );
 }
+

--- a/src/main/java/com/planit/domain/post/service/PostService.java
+++ b/src/main/java/com/planit/domain/post/service/PostService.java
@@ -18,6 +18,7 @@ import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -47,10 +48,9 @@ public class PostService {
         int size
     ) {
         Pageable pageable = PageRequest.of(page, size, Sort.by(sortOption.getSortProperty()).descending());
-        String pattern = search == null || search.isBlank() ? "%" : "%" + search + "%";
+        String pattern = buildSearchPattern(search);
         Page<PostRepository.PostSummary> result = postRepository.searchByBoardType(
             boardType.name(),
-            search,
             pattern,
             pageable
         );
@@ -66,7 +66,9 @@ public class PostService {
                 summary.getLikeCount(),
                 summary.getCommentCount(),
                 summary.getRepresentativeImageId(),
-                summary.getRankingScore()
+                summary.getRankingScore(),
+                summary.getPlaceName(),
+                summary.getTripTitle()
             ))
             .collect(Collectors.toList());
         return new PostListResponse(items, result.hasNext());
@@ -198,5 +200,12 @@ public class PostService {
         public String getSortProperty() {
             return sortProperty;
         }
+    }
+
+    private String buildSearchPattern(String search) {
+        if (search == null || search.isBlank()) {
+            return "%";
+        }
+        return "%" + search.trim().toLowerCase(Locale.ROOT) + "%";
     }
 }


### PR DESCRIPTION
## 개요
자유게시판 게시글 목록에서 **검색어 기반 조회 기능**을 구현했습니다.  
제목/본문을 대상으로 부분 검색이 가능하며, 검색 결과에 최소한의 장소/여행 정보도 함께 반환하도록 확장했습니다.

---

## 주요 구현 내용
- 게시글 목록 API에 `search` 파라미터 추가
- 제목(title) / 본문(content) 기준 검색 지원 (대소문자 무시)
- Soft delete 정책 반영
  - 삭제된 게시글(`posts.is_deleted = 1`) 제외
  - 삭제된 사용자(`users.is_deleted = 1`)의 게시글 제외
- 검색 결과 목록에 대표 장소명 / 여행명 포함
  - `posted_places → places.name`
  - `posted_plans → trips.title`
- 페이징 및 최신순 정렬 유지

---

## 기술적 상세
- Native Query 기반 검색 쿼리 작성
- `PostSummary` Projection을 활용해 목록 조회 성능 최적화
- 검색어 전처리(`trim`) 및 LIKE 패턴 처리
- OpenAPI(Swagger) 응답 스키마에 `placeName`, `tripTitle` 필드 노출

---

## 테스트
- 자유게시판 게시글 검색 정상 동작 확인
- 검색어 없음 / 검색 결과 없음 케이스 검증
- 삭제된 게시글 및 탈퇴 유저 게시글 미노출 확인

---

## 참고
- 검색 결과는 UI에서 게시글이 **어떤 장소/여행과 연관된 결과인지** 식별할 수 있도록
  최소 정보만 제공하는 방향으로 설계했습니다.