### PR TITLE
[feat] 게시글 목록 정렬 기능 구현

### DIFF
--- a/src/main/java/com/planit/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/planit/domain/post/repository/PostRepository.java
@@ -72,7 +72,10 @@ public interface PostRepository
                             + "and ( :pattern = '%' "
                             + "   or lower(p.title) like lower(:pattern) "
                             + "   or lower(p.content) like lower(:pattern) ) "
-                            + "order by p.created_at desc",
+                            + "order by "
+                            + " case when :sortOption = 'COMMENTS' then commentCount "
+                            + "      when :sortOption = 'LIKES' then likeCount "
+                            + "      else p.created_at end desc",
             countQuery =
                     "select count(*) "
                             + "from posts p "
@@ -86,9 +89,10 @@ public interface PostRepository
             nativeQuery = true
     )
     Page<PostSummary> searchByBoardType(
-            @Param("boardType") String boardType,
-            @Param("pattern") String pattern,
-            Pageable pageable
+        @Param("boardType") String boardType,
+        @Param("pattern") String pattern,
+        @Param("sortOption") String sortOption,
+        Pageable pageable
     );
 
     /**
@@ -99,4 +103,3 @@ public interface PostRepository
             Pageable pageable
     );
 }
-

--- a/src/main/java/com/planit/domain/post/service/PostService.java
+++ b/src/main/java/com/planit/domain/post/service/PostService.java
@@ -52,6 +52,7 @@ public class PostService {
         Page<PostRepository.PostSummary> result = postRepository.searchByBoardType(
             boardType.name(),
             pattern,
+            sortOption.name(),
             pageable
         );
         List<PostSummaryResponse> items = result.getContent()


### PR DESCRIPTION
## 작업 내용

게시글 목록 조회 시 다양한 기준으로 정렬할 수 있도록 기능을 구현했습니다.

### 1. 게시글 정렬 기능 추가
- 최신순 정렬 (`created_at DESC`)
- 좋아요순 정렬 (좋아요 개수 기준)
- 댓글순 정렬 (삭제되지 않은 댓글 수 기준)

### 2. 정렬 안정성 및 정확도 개선
- 삭제된 게시글(`is_deleted = true`) 제외
- 삭제된 댓글(`is_deleted = true`) 제외하여 댓글 수 계산
- 탈퇴 유저의 게시글 노출 정책에 맞게 필터링 처리

### 3. 사용자별 상태 정보 포함
- 로그인 사용자 기준, 게시글에 대한 좋아요 여부 반환

---

## 관련 테이블

- `posts`
- `users`
- `post_likes`
- `comments`
- `post_ranking_snapshots`

---

## 구현 방식

- 정렬 기준에 따라 동적 정렬 조건 적용
- 좋아요/댓글 수는 `LEFT JOIN` + `COUNT` 기반으로 계산
- 목록 조회 성능을 고려하여 불필요한 JOIN 최소화

---

## API 변경 사항

### 요청 파라미터
| 파라미터 | 설명 |
|--------|------|
| `sort` | 정렬 기준 (`LATEST`, `LIKE`, `COMMENT`) |

### 응답 예시
```json
{
  "postId": 1,
  "title": "게시글 제목",
  "likeCount": 10,
  "commentCount": 5,
  "likedByMe": true,
  "createdAt": "2026-01-27T10:30:00"
}