### PR TITLE
[feat] PLAN_SHARE 게시글 대표 이미지 override 구현

### DIFF
--- a/src/main/java/com/planit/domain/post/controller/PostController.java
+++ b/src/main/java/com/planit/domain/post/controller/PostController.java
@@ -188,16 +188,14 @@ public class PostController {
         if (sort == null || sort.isBlank()) {
             return PostService.SortOption.LATEST;
         }
-        switch (sort.trim().toLowerCase(Locale.ROOT)) {
-            case "latest":
-                return PostService.SortOption.LATEST;
-            case "comment":
-                return PostService.SortOption.COMMENTS;
-            case "like":
-                return PostService.SortOption.LIKES;
-            default:
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "*지원하지 않는 정렬 방식입니다.");
-        }
+
+        return switch (sort.trim().toLowerCase(Locale.ROOT)) {
+            case "latest" -> PostService.SortOption.LATEST;
+            case "comments_1y", "comment" -> PostService.SortOption.COMMENTS_1Y;
+            case "likes_1y", "like" -> PostService.SortOption.LIKES_1Y;
+            default -> throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST, "*지원하지 않는 정렬 방식입니다.");
+        };
     }
 
     private BoardType parseBoardType(String boardType) {

--- a/src/main/java/com/planit/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/planit/domain/post/repository/PostRepository.java
@@ -88,8 +88,8 @@ public interface PostRepository
                             + "   or lower(p.title) like lower(:pattern) "
                             + "   or lower(p.content) like lower(:pattern) ) "
                             + "order by case\n"
-                            + " when :sortOption = 'COMMENTS' then commentCount\n"
-                            + " when :sortOption = 'LIKES' then likeCount\n"
+                            + " when :sortOption in ('COMMENTS', 'COMMENTS_1Y') then commentCount\n"
+                            + " when :sortOption in ('LIKES', 'LIKES_1Y') then likeCount\n"
                             + " else p.created_at\n"
                             + " end desc",
             countQuery =

--- a/src/main/java/com/planit/domain/post/service/PostService.java
+++ b/src/main/java/com/planit/domain/post/service/PostService.java
@@ -328,19 +328,9 @@ public class PostService {
 
     /** 리스트 정렬 옵션 */
     public enum SortOption {
-        LATEST("createdAt"),
-        COMMENTS("commentCount"),
-        LIKES("likeCount");
-
-        private final String sortProperty;
-
-        SortOption(String sortProperty) {
-            this.sortProperty = sortProperty;
-        }
-
-        public String getSortProperty() {
-            return sortProperty;
-        }
+        LATEST,
+        COMMENTS_1Y,
+        LIKES_1Y
     }
 
     private String buildSearchPattern(String search) {


### PR DESCRIPTION
- PLAN_SHARE 게시글의 대표 이미지를 Trip 첫 장소 기준으로 override
- 기존 native query 구조 유지
- Service 레벨 후처리 방식 적용