### PR TITLE
[feat] 게시글 3개 게시판 타입 통합 및 생성/수정 로직 확장

### DIFF
--- a/src/main/java/com/planit/domain/post/dto/PostDetailResponse.java
+++ b/src/main/java/com/planit/domain/post/dto/PostDetailResponse.java
@@ -20,6 +20,13 @@ public class PostDetailResponse {
     private final Boolean likedByRequester; // 현재 요청자가 좋아요 눌렀는지
     private final List<CommentInfo> comments; // 댓글 목록 (20개)
     private final Boolean editable; // 현재 요청자가 작성자인지 (수정/삭제 버튼 노출 판단)
+    // PLACE_RECOMMEND 전용 필드
+    private final String placeName;
+    private final String googlePlaceId;
+    private final String placeImageUrl;
+    private final String city;
+    private final String country;
+    private final Integer rating;
 
     public PostDetailResponse(Long postId,
                               String boardName,
@@ -47,6 +54,52 @@ public class PostDetailResponse {
         this.likedByRequester = likedByRequester;
         this.comments = comments == null ? Collections.emptyList() : comments;
         this.editable = editable;
+        this.placeName = null;
+        this.googlePlaceId = null;
+        this.placeImageUrl = null;
+        this.city = null;
+        this.country = null;
+        this.rating = null;
+    }
+
+    public PostDetailResponse(Long postId,
+                              String boardName,
+                              String boardDescription,
+                              String title,
+                              String content,
+                              LocalDateTime createdAt,
+                              AuthorInfo author,
+                              List<PostImage> images,
+                              Integer likeCount,
+                              Integer commentCount,
+                              Boolean likedByRequester,
+                              List<CommentInfo> comments,
+                              Boolean editable,
+                              String placeName,
+                              String googlePlaceId,
+                              String placeImageUrl,
+                              String city,
+                              String country,
+                              Integer rating) {
+        this.postId = postId;
+        this.boardName = boardName;
+        this.boardDescription = boardDescription;
+        this.title = title;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.author = author;
+        this.images = images == null ? Collections.emptyList() : images;
+        this.likeCount = likeCount;
+        this.commentCount = commentCount;
+        this.likedByRequester = likedByRequester;
+        this.comments = comments == null ? Collections.emptyList() : comments;
+        this.editable = editable;
+        this.placeName = placeName;
+        this.googlePlaceId = googlePlaceId;
+        this.placeImageUrl = placeImageUrl;
+        this.city = city;
+        this.country = country;
+        this.rating = rating;
     }
 
     @Getter

--- a/src/main/java/com/planit/domain/post/dto/PostUpdateRequest.java
+++ b/src/main/java/com/planit/domain/post/dto/PostUpdateRequest.java
@@ -1,11 +1,9 @@
 package com.planit.domain.post.dto;
 
-import com.planit.domain.post.entity.BoardType;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import java.util.Collections;
@@ -34,10 +32,6 @@ public class PostUpdateRequest {
     @NotBlank(message = "*내용을 입력해주세요.")
     @Size(max = 2000, message = "*내용은 최대 2000자까지 작성할 수 있습니다.")
     private String content;
-
-    @Parameter(description = "게시판 유형")
-    @NotNull(message = "*게시판 유형을 선택해주세요.")
-    private BoardType boardType;
 
     @Parameter(description = "PLAN_SHARE일 때 연결할 plan ID")
     private Long planId;

--- a/src/main/java/com/planit/domain/post/entity/PostedPlace.java
+++ b/src/main/java/com/planit/domain/post/entity/PostedPlace.java
@@ -19,13 +19,14 @@ public class PostedPlace {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "posted_place_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
-    @Column(name = "place_id")
+    @Column(name = "place_id", nullable = false)
     private Long placeId;
 
     @Column(name = "google_place_id", length = 255)

--- a/src/main/java/com/planit/domain/post/service/PostService.java
+++ b/src/main/java/com/planit/domain/post/service/PostService.java
@@ -37,6 +37,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -197,8 +198,9 @@ public class PostService {
     }
 
     private void saveRecommendedPlace(Post post, PlaceRecommendationPayload payload) {
+        Long placeId = Objects.requireNonNull(payload.placeId(), "*장소를 선택해주세요.");
         postedPlaceRepository.save(
-                new PostedPlace(post, payload.placeId(), payload.googlePlaceId(), payload.rating()));
+                new PostedPlace(post, placeId, payload.googlePlaceId(), payload.rating()));
     }
 
     private PlaceRecommendationPayload validatePlaceRecommendation(PostCreateRequest request) {
@@ -319,11 +321,8 @@ public class PostService {
         post.setContent(request.getContent());
         post.touchUpdatedAt(now);
         List<Long> imageIds = Collections.emptyList();
-        BoardType requestedBoardType = request.getBoardType();
-        if (requestedBoardType != post.getBoardType()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "*게시판 유형을 변경할 수 없습니다.");
-        }
-        switch (requestedBoardType) {
+        BoardType currentBoardType = post.getBoardType();
+        switch (currentBoardType) {
             case FREE -> {
                 deleteExistingPostImages(postId);
                 imageIds = savePostImages(postId, request.getImageKeys(), now);


### PR DESCRIPTION
## 변경 사항
- places 테이블에 없는 city/country 컬럼 제거
- 상세조회 native query 수정
- boardType 수정 시 고정 처리
- 프론트 update 요청 수정

## 테스트
- 자유게시판 상세조회 정상 200 확인
- 게시글 수정 정상 동작 확인